### PR TITLE
#152192090 Users who do not have an account on the app should get a link to log into the app using their email address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,16 @@ before emails will work. healthchecks uses
 [djmail](http://bameda.github.io/djmail/) for sending emails asynchronously.
 Djmail is a BSD Licensed, simple and nonobstructive django email middleware.
 It can be configured to use any regular Django email backend behind the
-scenes. For example, the healthchecks.io site uses
-[django-ses-backend](https://github.com/piotrbulinski/django-ses-backend/)
-and the email configuration in `hc/local_settings.py` looks as follows:
+scenes. For example, one can configure it to use the default django email backend by editing 'local_settings' as follows:
 
-    DJMAIL_REAL_BACKEND = 'django_ses_backend.SESBackend'
-    AWS_SES_ACCESS_KEY_ID = "put-access-key-here"
-    AWS_SES_SECRET_ACCESS_KEY = "put-secret-access-key-here"
-    AWS_SES_REGION_NAME = 'us-east-1'
-    AWS_SES_REGION_ENDPOINT = 'email.us-east-1.amazonaws.com'
+    EMAIL_BACKEND = "djmail.backends.default.EmailBackend"
+    DJMAIL_REAL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    EMAIL_HOST = "your-mail-server-address"
+    EMAIL_PORT = "email-outgoing-port"
+    EMAIL_HOST_USER = "your-email-address"
+    EMAIL_HOST_PASSWORD = "your-email-password"
+    EMAIL_USE_TLS = True
+    EMAIL_USE_SSL = False
 
 ## Sending Status Notifications
 

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -133,7 +133,15 @@ STATICFILES_FINDERS = (
 )
 COMPRESS_OFFLINE = True
 
+# Email configuration with django default backend
 EMAIL_BACKEND = "djmail.backends.default.EmailBackend"
+DJMAIL_REAL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.environ.get("EMAIL_HOST")
+EMAIL_PORT = os.environ.get("EMAIL_PORT")
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False
 
 # Slack integration -- override these in local_settings
 SLACK_CLIENT_ID = None


### PR DESCRIPTION
#### What does this PR do?
This PR configures healthchecks with email settings that allows users who do not have an account on the app to get a link to log into the app using their email address.
#### Description of Task to be completed?
It should be possible to send out email login links
#### How should this be manually tested?
After proper setup, the heroku app should send emails with the login links when the user clicks the login button and fills out the correct email address
#### Any background context you want to provide?
The healthchecks project initially ships with email configuration using a django-ses-backend which requires subscription to a paid AWS platform.
#### What are the relevant pivotal tracker stories?
#152192090